### PR TITLE
fix: Add model name to downstream API payload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,11 @@
 LLM_1_NAME="Local Llama3"
 LLM_1_ENDPOINT="http://localhost:11434/v1/chat/completions"
 LLM_1_KEY="ollama"
+# The actual model name the API expects (e.g., 'llama3'). Defaults to the NAME if not set.
+LLM_1_MODEL_NAME="llama3"
 
 # Expert 2 (e.g., OpenAI's GPT-4) - uncomment and configure to use
 # LLM_2_NAME="OpenAI GPT-4"
 # LLM_2_ENDPOINT="https://api.openai.com/v1/chat/completions"
 # LLM_2_KEY="sk-your-openai-api-key"
+# LLM_2_MODEL_NAME="gpt-4-turbo"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The backend will load any environment variables that follow this pattern:
 - `LLM_[INDEX]_NAME`: The display name for the expert (e.g., "OpenAI GPT-4").
 - `LLM_[INDEX]_ENDPOINT`: The full API endpoint URL.
 - `LLM_[INDEX]_KEY`: The secret API key for that service.
+- `LLM_[INDEX]_MODEL_NAME`: (Optional) The specific model name the API expects (e.g., "gpt-4-turbo"). If not provided, it defaults to the `NAME`.
 
 You can add as many experts as you like by incrementing the index (e.g., `LLM_1_...`, `LLM_2_...`, etc.). The names you provide will appear in the dropdown menus in the application.
 

--- a/server.py
+++ b/server.py
@@ -24,8 +24,15 @@ def load_experts_from_env():
             name = value
             endpoint = os.getenv(f"LLM_{index}_ENDPOINT")
             api_key = os.getenv(f"LLM_{index}_KEY")
+            # Get the optional model name, fallback to the display name if not provided
+            model_name = os.getenv(f"LLM_{index}_MODEL_NAME", name)
+
             if name and endpoint and api_key:
-                experts_config[name] = {"endpoint": endpoint, "api_key": api_key}
+                experts_config[name] = {
+                    "endpoint": endpoint,
+                    "api_key": api_key,
+                    "model_name": model_name
+                }
     EXPERTS = experts_config
     if not EXPERTS:
         print("Warning: No LLM experts configured. Please set LLM_1_NAME, LLM_1_ENDPOINT, and LLM_1_KEY environment variables.")
@@ -122,11 +129,8 @@ def chat_handler():
         'Authorization': f'Bearer {expert["api_key"]}'
     }
 
-    # The 'model' in the payload for the downstream API might be different
-    # from our internal 'expert_name'. For now, we assume they are the same
-    # or that the downstream API doesn't require a model parameter if the
-    # endpoint is already model-specific. We'll just send the messages.
     payload = {
+        "model": expert["model_name"], # Use the specific model name for the downstream API
         "messages": data["messages"]
     }
 


### PR DESCRIPTION
This commit fixes a bug where the backend server was not including the `model` parameter in the JSON payload when forwarding requests to the configured LLM API. This caused a "400 Bad Request" error from services like Ollama that require this field.

Key changes:
- The `chat_handler` in `server.py` now correctly includes the `model` name in the forwarded request payload.
- Added support for an optional `LLM_[INDEX]_MODEL_NAME` environment variable to allow a user-friendly display name in the UI while sending a specific technical model name to the API.
- Updated `.env.example` and `README.md` to document the new optional variable.