### PR TITLE
feat: add ATProto identity verification endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,8 @@ LLM_1_MODEL_NAME="llama3"
 
 # SAM.gov API Key for Opportunity Search
 SAM_API_KEY="your-sam-gov-api-key-here"
+
+# ATProto Identity (OpenClaw Compatibility)
+# Provide the DID (Decentralized Identifier) for this agent.
+# Example: did:plc:12345abcdef...
+ATPROTO_DID="did:plc:your-agent-did-here"

--- a/server.py
+++ b/server.py
@@ -136,6 +136,15 @@ def load_experts_from_env():
 def index():
     return send_from_directory('.', 'sbir_agent.html')
 
+@app.route('/.well-known/atproto-did')
+def atproto_did():
+    did = os.getenv('ATPROTO_DID', 'did:plc:placeholder-agent-did')
+    return app.response_class(
+        response=did,
+        status=200,
+        mimetype='text/plain'
+    )
+
 @app.route('/api/experts', methods=['GET'])
 def get_experts():
     return jsonify(list(EXPERTS.keys()))

--- a/test_server.py
+++ b/test_server.py
@@ -10,6 +10,21 @@ def client():
     with app.test_client() as client:
         yield client
 
+def test_atproto_did_route_configured(client):
+    os.environ['ATPROTO_DID'] = 'did:plc:test-did-123'
+    response = client.get('/.well-known/atproto-did')
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'text/plain; charset=utf-8'
+    assert response.data.decode('utf-8') == 'did:plc:test-did-123'
+
+def test_atproto_did_route_default(client):
+    if 'ATPROTO_DID' in os.environ:
+        del os.environ['ATPROTO_DID']
+    response = client.get('/.well-known/atproto-did')
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'text/plain; charset=utf-8'
+    assert response.data.decode('utf-8') == 'did:plc:placeholder-agent-did'
+
 def test_organization_details_no_api_key(client):
     if "SAM_API_KEY" in os.environ:
         del os.environ["SAM_API_KEY"]


### PR DESCRIPTION
This pull request adds an HTTP well-known endpoint (`/.well-known/atproto-did`) for ATProto identity verification, fulfilling the requirement for the system to act as a specialized "open claw" agent. 

The route serves the DID as plain text, configured via the `ATPROTO_DID` environment variable. A placeholder default ensures it runs seamlessly without explicit setup.

It includes:
- Added `ATPROTO_DID` example in `.env.example`.
- Created a `/.well-known/atproto-did` Flask route.
- Created `test_atproto_did_route_configured` and `test_atproto_did_route_default` pytest cases to verify standard and fallback behavior.

---
*PR created automatically by Jules for task [17702741881088519741](https://jules.google.com/task/17702741881088519741) started by @LokiMetaSmith*